### PR TITLE
Correct server MIME type for modules

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/((?!src|assets|public|.*\\..*).*)",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
Update Vercel rewrite rule to correctly serve module scripts and static assets.

The previous `vercel.json` rewrite rule `"(.*)"` was too broad, redirecting all requests (including JavaScript modules) to `/index.html`. This caused a MIME type error because the browser expected JavaScript but received HTML. The updated rule `"/((?!src|assets|public|.*\\..*).*)"` now correctly excludes `src`, `assets`, `public` directories, and files with extensions, ensuring they are served with their proper MIME types.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-c8d06934-3d5e-4800-98f6-c422a671ae8b) · [Cursor](https://cursor.com/background-agent?bcId=bc-c8d06934-3d5e-4800-98f6-c422a671ae8b)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)