### PR TITLE
Resolve mobile nav hero overlap

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -99,8 +99,8 @@ const Navigation = () => {
         </div>
 
         {/* Mobile Navigation */}
-        {isOpen && (
-          <div className="md:hidden absolute top-16 left-0 right-0 bg-cyber-dark/98 backdrop-blur-md border-b border-cyber-green/20">
+        <div className={`md:hidden transition-all duration-300 ease-in-out ${isOpen ? 'max-h-screen opacity-100' : 'max-h-0 opacity-0 overflow-hidden'}`}>
+          <div className="bg-cyber-dark/98 backdrop-blur-md border-b border-cyber-green/20">
             <div className="flex flex-col space-y-1 p-4">
               {/* Mobile Status */}
               <div className="flex items-center justify-between text-xs font-mono mb-4 pb-2 border-b border-cyber-green/20">
@@ -137,7 +137,7 @@ const Navigation = () => {
               </Button>
             </div>
           </div>
-        )}
+        </div>
       </div>
     </nav>
   );

--- a/src/components/TerminalInterface.tsx
+++ b/src/components/TerminalInterface.tsx
@@ -251,7 +251,7 @@ const TerminalInterface = () => {
   }, [currentInput]);
 
   return (
-    <section className="min-h-screen flex items-center justify-center relative matrix-bg py-20">
+    <section className="min-h-screen flex items-center justify-center relative matrix-bg py-20 pt-24 md:pt-20">
       <div className="container mx-auto px-4">
         <div className="max-w-4xl mx-auto">
           {/* Terminal Window */}


### PR DESCRIPTION
Adjust mobile navigation and hero section to prevent overlap when the navigation bar is expanded.

The mobile navigation previously used `absolute` positioning, causing it to overlay the hero section. This PR changes the mobile navigation to push content down using height-based transitions and adds top padding to the hero section to accommodate the fixed navigation bar.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-61510f1d-73d2-4844-b5bd-5c41d1ffc919) · [Cursor](https://cursor.com/background-agent?bcId=bc-61510f1d-73d2-4844-b5bd-5c41d1ffc919)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)