### PR TITLE
Reposition nav bar tooltips

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -60,7 +60,7 @@ const Navigation = () => {
                   {item.command}
                 </button>
                 {/* Tooltip */}
-                <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-cyber-dark border border-cyber-green/30 rounded text-xs text-cyber-green opacity-0 group-hover:opacity-100 transition-opacity duration-200 whitespace-nowrap pointer-events-none">
+                <div className="absolute top-full left-1/2 transform -translate-x-1/2 mt-2 px-2 py-1 bg-cyber-dark border border-cyber-green/30 rounded text-xs text-cyber-green opacity-0 group-hover:opacity-100 transition-opacity duration-200 whitespace-nowrap pointer-events-none">
                   {item.tooltip}
                 </div>
               </div>


### PR DESCRIPTION
Adjust navigation bar tooltip positioning to appear below links, preventing cutoff.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-c9333139-e3ee-462d-b307-7b6e83b23dc1) · [Cursor](https://cursor.com/background-agent?bcId=bc-c9333139-e3ee-462d-b307-7b6e83b23dc1)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)