### PR TITLE
Remove cryptotool page navigation bar

### DIFF
--- a/src/pages/CryptoToolPage.tsx
+++ b/src/pages/CryptoToolPage.tsx
@@ -1,11 +1,9 @@
-import Navigation from "@/components/Navigation";
 import CryptoTool from "@/components/CryptoTool";
 
 const CryptoToolPage = () => {
   return (
     <div className="min-h-screen bg-cyber-dark">
-      <Navigation />
-      <main className="pt-16">
+      <main>
         <CryptoTool />
       </main>
     </div>


### PR DESCRIPTION
Remove the navigation bar from the cryptotool page to provide a full-screen experience.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-3313ed52-5d26-4ea7-afd5-4142c1fcd71c) · [Cursor](https://cursor.com/background-agent?bcId=bc-3313ed52-5d26-4ea7-afd5-4142c1fcd71c)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)