### PR TITLE
Hero scroll and cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,5 @@
 import { Toaster } from "@/components/ui/toaster";
-import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import InitialBootLoader from "@/components/animations/InitialBootLoader";
 import RouteLoadingBar from "@/components/animations/RouteLoadingBar";
@@ -15,31 +13,26 @@ import FirewallRuleChallengePage from "./pages/FirewallRuleChallengePage";
 import CodeVulnerabilityAuditPage from "./pages/CodeVulnerabilityAuditPage";
 import NotFound from "./pages/NotFound";
 
-const queryClient = new QueryClient();
-
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <InitialBootLoader />
-      <BrowserRouter>
-        <RouteLoadingBar />
-        <ScrollProgressBar />
-        <ScrollRevealObserver />
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/rogue-file-hunt" element={<RogueFileHuntPage />} />
-          <Route path="/spot-the-phish" element={<SpotThePhishPage />} />
-          <Route path="/crypto-tool" element={<CryptoToolPage />} />
-          <Route path="/firewall-rule-challenge" element={<FirewallRuleChallengePage />} />
-          <Route path="/code-vulnerability-audit" element={<CodeVulnerabilityAuditPage />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+  <TooltipProvider>
+    <Toaster />
+    <InitialBootLoader />
+    <BrowserRouter>
+      <RouteLoadingBar />
+      <ScrollProgressBar />
+      <ScrollRevealObserver />
+      <Routes>
+        <Route path="/" element={<Index />} />
+        <Route path="/rogue-file-hunt" element={<RogueFileHuntPage />} />
+        <Route path="/spot-the-phish" element={<SpotThePhishPage />} />
+        <Route path="/crypto-tool" element={<CryptoToolPage />} />
+        <Route path="/firewall-rule-challenge" element={<FirewallRuleChallengePage />} />
+        <Route path="/code-vulnerability-audit" element={<CodeVulnerabilityAuditPage />} />
+        {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </BrowserRouter>
+  </TooltipProvider>
 );
 
 export default App;

--- a/src/components/modern/ModernHero.tsx
+++ b/src/components/modern/ModernHero.tsx
@@ -32,9 +32,22 @@ type ModernHeroProps = {
   className?: string;
 };
 
-function scrollToTarget(target: string) {
-  const el = document.querySelector(target);
-  el?.scrollIntoView({ behavior: "smooth" });
+function scrollToTarget(target?: string) {
+  if (target) {
+    const el = document.querySelector(target);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+      return;
+    }
+  }
+
+  // Fallback: scroll to the next section after the hero.
+  const home = document.getElementById("home");
+  let next = home?.nextElementSibling ?? null;
+  while (next && !(next instanceof HTMLElement && next.tagName.toLowerCase() === "section")) {
+    next = next.nextElementSibling;
+  }
+  (next as HTMLElement | null)?.scrollIntoView({ behavior: "smooth", block: "start" });
 }
 
 export default function ModernHero({ copy, className }: ModernHeroProps) {
@@ -203,8 +216,8 @@ export default function ModernHero({ copy, className }: ModernHeroProps) {
             {/* Scroll indicator */}
             <motion.button
               type="button"
-              aria-label="Scroll to about section"
-              onClick={() => scrollToTarget("#about")}
+              aria-label="Scroll to next section"
+              onClick={() => scrollToTarget("#education")}
               className={cn(
                 "absolute bottom-5 left-1/2 -translate-x-1/2",
                 "inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.02] px-3 py-1.5",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
-import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -12,8 +11,6 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
-    mode === 'development' &&
-    componentTagger(),
   ].filter(Boolean),
   resolve: {
     alias: {


### PR DESCRIPTION
Fixes the ModernHero scroll button and removes unused dependencies and development plugins.

The scroll button in `ModernHero` was targeting a non-existent `#about` section, causing it to fail. This PR updates the target to `#education` and adds a robust fallback to scroll to the next section. Additionally, it cleans up unused `@tanstack/react-query` setup and the `lovable-tagger` Vite plugin.

---
<a href="https://cursor.com/background-agent?bcId=bc-80b3053a-20a0-4075-9f29-503b80c6669a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80b3053a-20a0-4075-9f29-503b80c6669a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

